### PR TITLE
Fix parsing of visgroups

### DIFF
--- a/fgd/visgroups.cfg
+++ b/fgd/visgroups.cfg
@@ -249,9 +249,9 @@
 		* `info_node_link_logic`
 		* `info_node_link_oneway`
 	- Brush Entities
-	 	- Clips
-	 		* `func_clip_vphysics`
-	 		* `func_vehicleclip` 
+		- Clips
+			* `func_clip_vphysics`
+			* `func_vehicleclip` 
 		- Triggers
 			- Death Triggers
 				* `trigger_hurt`


### PR DESCRIPTION
Visgroup parsing only strips tabs, so the spaces here are breaking generation.

https://github.com/TeamSpen210/HammerAddons/blob/e0196d4dca887326a1d8d67023046712b9d3782d/unify_fgd.py#L385