### PR TITLE
Dont base light_environment on BaseLight

### DIFF
--- a/fgd/point/light/light_environment.fgd
+++ b/fgd/point/light/light_environment.fgd
@@ -1,4 +1,4 @@
-@PointClass base(BaseLight, Angles) 
+@PointClass base(Angles) 
 	autovis(Lights, Environment Light)
 	iconsprite("editor/ficool2/light_environment.vmt") 
 	color(255 255 0)


### PR DESCRIPTION
This shouldn't be basing off of BaseLight, as constant/linear/quadratic/etc. isnt used in this ent for any game.

Found from a bug report for Momentum: https://discord.com/channels/235111289435717633/356398721790902274/832962900393852949