### PR TITLE
Use python 3.9 for workflow builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
       - name: Install srctools
         run: .\install_srctools.bat
       - name: FGD build and folder copy
@@ -25,6 +29,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
       - name: Install srctools
         run: bash ./install_srctools.sh
       - name: FGD build and folder copy


### PR DESCRIPTION
Github actions builders run an older version and srctools was recently updated to use 3.9+ features (see https://github.com/TeamSpen210/srctools/pull/7)