### PR TITLE
Remove redundant spawnflag numbers

### DIFF
--- a/fgd/point/game/game_metadata.fgd
+++ b/fgd/point/game/game_metadata.fgd
@@ -6,8 +6,8 @@
 	[
 	spawnflags(flags) =
 		[
-		1: "[1] Update Steam" : 1
-		2: "[2] Update Discord" : 1
+		1: "Update Steam" : 1
+		2: "Update Discord" : 1
 		]
 
 	SetRPCState(string) : "RPC State" : "" : "Sets the 'state' that should be reported to rich presence clients like Discord. Shows the mod's name from gameinfo.txt by default."

--- a/fgd/point/math/math_vector.fgd
+++ b/fgd/point/math/math_vector.fgd
@@ -8,9 +8,9 @@
 	
 	spawnflags(flags) =
 		[
-		1 : "[1] Disable X" : 0
-		2 : "[2] Disable Y" : 0
-		4 : "[4] Disable Z" : 0
+		1 : "Disable X" : 0
+		2 : "Disable Y" : 0
+		4 : "Disable Z" : 0
 		]
 
 	// Inputs


### PR DESCRIPTION
These are added on compile so having them here means they'll be duplicated. See https://github.com/ChaosInitiative/Chaos-FGD/pull/137