### PR TITLE
Assortment Pull Request #1.5, "I read through SDK 2013" edition

### DIFF
--- a/fgd/bases/gibshooterbase.fgd
+++ b/fgd/bases/gibshooterbase.fgd
@@ -14,13 +14,25 @@
 	m_flvelocity(integer) : "Gib Velocity" : 200 : "Speed of the fired gibs."
 	m_flvariance(float) : "Course Variance" : "0.15" : "How much variance in the direction gibs are fired."
 	m_flgiblife(float) : "Gib Life" : 4 : "Time in seconds for gibs to live +/- 5%."
-
+	
+	Simulation[engine](integer) : "Simulation Type" : 0 : "The kind of physics simulation to use for the gibs fired out."
+	Simulation(choices) : "Simulation Type" : 0 : "The kind of physics simulation to use for the gibs fired out." =
+		[
+		0: "Point"
+		1: "Physics"
+		2: "Ragdoll"
+		]
+	
 	lightingorigin(target_destination) : "Lighting Origin" : : "Select an info_lighting to specify a location to sample lighting from " +
 		"for all gibs spawned by this shooter, instead of their own origins."
+	nogibshadows(boolean) : "Disable Shadows on Gibs" : 0
+	
 	spawnflags(flags)  =
 		[
 		1: "Repeatable" : 0
+		4: "Strict remove after lifetime" : 0 [-HLS]
 		]
+		
 
 	// Inputs
 	input Shoot(void) : "Force the gibshooter to create and shoot a gib."

--- a/fgd/bases/gibshooterbase.fgd
+++ b/fgd/bases/gibshooterbase.fgd
@@ -25,7 +25,6 @@
 	
 	lightingorigin(target_destination) : "Lighting Origin" : : "Select an info_lighting to specify a location to sample lighting from " +
 		"for all gibs spawned by this shooter, instead of their own origins."
-	nogibshadows(boolean) : "Disable Shadows on Gibs" : 0
 	
 	spawnflags(flags)  =
 		[

--- a/fgd/brush/func/func_nobuild.fgd
+++ b/fgd/brush/func/func_nobuild.fgd
@@ -4,6 +4,7 @@
 	allowsentry(boolean) : "Allow Sentries" : 0 : "Sentries are allowed to be built in this volume."
 	allowdispenser(boolean) : "Allow Dispensers" : 0 : "Dispensers are allowed to be built in this volume."
 	allowteleporters(boolean) : "Allow Teleporters" : 0 : "Teleporters are allowed to be built in this volume."
+	destroybuildings(boolean) : "Destroy Buildings" : 0 : "Destroy buildings when this volume is activated."
 
 	input SetActive( void ) : "Set Active"
 	input SetInactive( void ) : "Set InActive"

--- a/fgd/brush/func/func_tankmortar.fgd
+++ b/fgd/brush/func/func_tankmortar.fgd
@@ -1,4 +1,4 @@
-@SolidClass base(BaseTank) = func_tankmortar: "Brush turret, which fires a morta shot. This is used for the HL2 Combine Nexus 'suppression device'."
+@SolidClass base(BaseTank) = func_tankmortar: "Brush turret, which fires a mortar shot. This is used for the HL2 Combine Nexus 'suppression device'."
 	[
 	imagnitude(integer) : "Explosion Magnitude" : 100
 	firedelay(string) : "Shell travel time" : "2" : "How long after the turret fires before the shell impacts"
@@ -16,6 +16,7 @@
 		100679691: "MASK_SHOT_HULL (hits NPCs)"
 	]
 	// Inputs
+	input ShootGun(void) : "Manually shoots the gun."
 	input FireAtWill(void) : "Allow tank to fire next shot as soon as ready."
 	
 	@resources

--- a/fgd/point/env/env_blood.fgd
+++ b/fgd/point/env/env_blood.fgd
@@ -19,6 +19,9 @@
 		2: "Blood Stream" : 0
 		4: "On Player" : 0
 		8: "Spray decals" : 0
+		16: "Blood Cloud" : 0
+		32: "Blood Drops" : 0
+		64: "Gore" : 0
 		]
 
 	// Inputs

--- a/fgd/point/env/env_rotorshooter.fgd
+++ b/fgd/point/env/env_rotorshooter.fgd
@@ -1,34 +1,8 @@
-@PointClass base(gibshooterbase) 
+@PointClass base(env_shooter) 
 	iconsprite("editor/ficool2/env_rotorshooter.vmt") 
 	line(255 255 255, targetname, lightingorigin) 
 	color(200 200 0) = env_rotorshooter: "An entity that creates gibs when it's within the influence of a helicopter's rotor wash."
 	[
-	shootmodel(studio) : "Model" : : "Thing to shoot out.  Can be a .mdl or a .vmt."
-
-	shootsounds[engine](integer) : "Material Sound": -1
-	shootsounds(choices) : "Material Sound" : -1 =
-		[
-		-1: "None"
-		0: "Glass"
-		1: "Wood"
-		2: "Metal"
-		3: "Flesh"
-		4: "Concrete"
-		]
-
-	simulation[engine](integer) : "Simulation Type" : 0
-	simulation(choices) : "Simulation Type" : "0" =
-		[
-		0: "Point"
-		1: "Physics"
-		2: "Ragdoll"
-		]
-
-	skin(integer) : "Gib Skin" : 0 : "Some models have multiple versions of their textures, called skins. Set this to a number other than 0 to use that skin on all gibs produced by this shooter."
-	spawnflags(flags) : "spawnflags" =
-		[
-		2: "On fire" : 0
-		]
 
 	rotortime(float) : "Time Under Rotor" : 1 : "The average time it has to be under the rotor before it shoots a gib."
 	rotortimevariance(float) : "Time variance" : 0.3 : "The random amount to vary the time it has to be under the rotor before it shoots a gib."

--- a/fgd/point/env/env_shooter.fgd
+++ b/fgd/point/env/env_shooter.fgd
@@ -17,25 +17,15 @@
 		4: "Concrete"
 		]
 
-	simulation[engine](integer) : "Simulate"
-	simulation(choices) : "Simulate" : "0" =
-		[
-		0: "Point"
-		1: "Physics"
-		2: "Ragdoll"
-		]
-
 	skin(integer) : "Gib Skin" : 0 : "Some models have multiple versions of their textures, called skins. Set this to a number other than 0 to use that skin on all gi" + "bs produced by this shooter."
 	spawnflags(flags)  =
 		[
 		2: "On fire" : 0
-		4: "strict remove after lifetime" : 0
 		]
 
-	nogibshadows(boolean) : "Disable Shadows on Gibs" : 0
 	gibgravityscale(float) : "Gib gravity scale" : 1 : "ONLY WORKS FOR POINT GIBS. This field allows you to scale gravity so that gibs fall faster, slower, or not at all."
 
-	massoverride(float) : "Mass override" : 0 : "EPISODIC ONLY. Specify an arbitrary mass for the gibs emitted by me."
+	massoverride[EP1, EP2](float) : "Mass override" : 0 : "EPISODIC ONLY. Specify an arbitrary mass for the gibs emitted by me."
 
 	bloodcolor[engine](integer) : "Blood Color" : -1
 	bloodcolor[MESA](choices) : "Blood Color" : -1 =

--- a/fgd/point/env/env_shooter.fgd
+++ b/fgd/point/env/env_shooter.fgd
@@ -23,6 +23,7 @@
 		2: "On fire" : 0
 		]
 
+	nogibshadows(boolean) : "Disable Shadows on Gibs" : 0
 	gibgravityscale(float) : "Gib gravity scale" : 1 : "ONLY WORKS FOR POINT GIBS. This field allows you to scale gravity so that gibs fall faster, slower, or not at all."
 
 	massoverride[EP1, EP2](float) : "Mass override" : 0 : "EPISODIC ONLY. Specify an arbitrary mass for the gibs emitted by me."

--- a/fgd/point/env/env_tracer.fgd
+++ b/fgd/point/env/env_tracer.fgd
@@ -1,0 +1,9 @@
+
+@PointClass base(BaseEntityPoint) 
+	appliesto(ASW, EP1, EP2, HL2, MBase, P1, CSGO, Mesa) = env_tracer: "An entity that fires a tracer between itself and a specified target, with a configurable delay."
+	[
+	target(target_destination) : "Target" : : "The target to shoot a tracer at."
+  delay(float) : "Delay" : 1 : "A delay to fire this tracer at, specified in seconds."
+
+	@resources []
+	]

--- a/fgd/point/game/game_weapon_manager.fgd
+++ b/fgd/point/game/game_weapon_manager.fgd
@@ -10,5 +10,6 @@
 	ammomod(float) : "Ammo modifier" : 1 : "Modifier for ammount of ammo dropped by a weapon."
 
 	// Inputs
+	input SetMaxPieces(float) : "Adjust the maximum amount of the weapon allowed."
 	input SetAmmoModifier(float) : "Adjust the ammo modifier."
 	]

--- a/fgd/point/logic/logic_measure_movement.fgd
+++ b/fgd/point/logic/logic_measure_movement.fgd
@@ -44,7 +44,7 @@
 	// Inputs
 	input SetMeasureTarget(string) : "Set the Entity to Measure, whose movement should be measured."
 	input SetMeasureReference(string) : "Set the Measure Reference entity."
-	input Target(string) : "Set the Entity to Move, which will be moved to mimic the measured entity."
+	input SetTarget(string) : "Set the Entity to Move, which will be moved to mimic the measured entity."
 	input SetTargetReference(string) : "Set the Movement Reference entity."
 	input SetTargetScale(float) : "Set the scale to divide the measured movements by."
 	input SetMeasureType[MBase](integer) : "Sets the measurement type."

--- a/fgd/point/npc/npc_citizen.fgd
+++ b/fgd/point/npc/npc_citizen.fgd
@@ -153,7 +153,9 @@
 	input SetMedicOff(void) : "Set the medic flag off. Will not change the model or skin of the citizen."
 	input SetAmmoResupplierOn(void) : "Set the ammo-resupplier flag on. Will not change the model or skin of the citizen."
 	input SetAmmoResupplierOff(void) : "Set the ammo-resupplier flag off. Will not change the model or skin of the citizen."
+	input ThrowHealthKit[episodic](void) : "Makes the citizen throw a medkit, similar to how Griggs in Half-Life 2: Episode Two heals you."
 	input SetTossMedkits[MBase](bool) : "Sets whether this NPC can toss medkits."	
+	input SpeakIdleResponse[complete](void) : "Makes the citizen speak an idle line, if any. Automatically fired by code, but can also be manually fired, to not much effect."
 
 	input Surrender[EZ2](void) : "Immediately surrender to the !activator NPC/player."
 	input SetSurrenderFlags[EZ2](int) : "Set the surrendering flags to the provided value."

--- a/fgd/point/npc/npc_citizen.fgd
+++ b/fgd/point/npc/npc_citizen.fgd
@@ -153,7 +153,7 @@
 	input SetMedicOff(void) : "Set the medic flag off. Will not change the model or skin of the citizen."
 	input SetAmmoResupplierOn(void) : "Set the ammo-resupplier flag on. Will not change the model or skin of the citizen."
 	input SetAmmoResupplierOff(void) : "Set the ammo-resupplier flag off. Will not change the model or skin of the citizen."
-	input ThrowHealthKit[episodic](void) : "Makes the citizen throw a medkit, similar to how Griggs in Half-Life 2: Episode Two heals you."
+	input ThrowHealthKit[EP1, EP2](void) : "Makes the citizen throw a medkit, similar to how Griggs in Half-Life 2: Episode Two heals you."
 	input SetTossMedkits[MBase](bool) : "Sets whether this NPC can toss medkits."	
 	input SpeakIdleResponse[complete](void) : "Makes the citizen speak an idle line, if any. Automatically fired by code, but can also be manually fired, to not much effect."
 


### PR DESCRIPTION
I picked a random entity from a google sheet I made and looked it up in SDK 2013. Most of the inputs and keyvalues here are because of that, although it isn't much.

**Changes:**

`npc_citizen`:
- Added `ThrowHealthKit` and `SpeakIdleResponse` inputs
- Added `env_tracer`

`gibshooterbase`:
- `Simulation` keyvalue has been migrated from `env_shooter`, as it also works in `gibshooter`
- Same for the `Strict remove after lifetime` spawnflag, which is disabled in HLS from reading code(?)

`env_shooter`:
- Made the `massoverride` keyvalue exclusive to ep1 and ep2
- Additionally, based `env_rotorshooter` off of `env_shooter`, since SDK 2013 has it like that

`env_blood`:
- Added the `Blood Cloud`, `Blood Drops`, and `Gore` spawnflags (internally it's `Blood Gore` but I shortened it to make a bit more sense(?))

`game_weapon_manager`:
- Added `SetMaxPieces` input

`logic_measure_movement`:
- Changed `Target` input to `SetTarget` (not sure about this tbh)

`func_tankmortar`:
- Fixed a typo in description, added `ShootGun` input

`func_nobuild`:
- Added `destroybuildings` keyvalue to it, fixing a teensy tiny bit of #179 