### PR TITLE
Portal 2: fix Insert Disc movie filename misspell in `vgui_movie_display`

### DIFF
--- a/fgd/point/vgui/vgui_movie_display.fgd
+++ b/fgd/point/vgui/vgui_movie_display.fgd
@@ -60,7 +60,7 @@
 		"media/coop_bts_security_02.bik"	: "Coop Disc: Security 2"
 		"media/coop_bts_radar.bik"			: "Coop Disc: Unused Radar"
 		"media/coop_bts_security.bik"		: "Coop Disc: Unused Security"
-		"media/insert_disc.bik"				: "Insert Disc"
+		"media/insert_disk.bik"				: "Insert Disc"
 		"media/dlc1_endmovie.bik"			: "Art Therapy Outro"
 		
 		// Other


### PR DESCRIPTION
(mentioned in #244 )
Modified FGD for `vgui_movie_display` to fix misspell.