### PR TITLE
Vactubes: Delete the generated animation files once packed

### DIFF
--- a/transforms/vactubes/__init__.py
+++ b/transforms/vactubes/__init__.py
@@ -258,7 +258,8 @@ async def vactube_transform(ctx: Context) -> None:
     # Ensure they're all packed.
     for ext in MDL_EXTS:
         try:
-            mdl_file = full_loc.with_suffix(ext).open('rb')
+            mdl_filePath = full_loc.with_suffix(ext)
+            mdl_file = mdl_filePath.open('rb')
         except FileNotFoundError:
             pass
         else:
@@ -267,6 +268,8 @@ async def vactube_transform(ctx: Context) -> None:
                     Path('models', anim_mdl_name.with_suffix(ext)),
                     data=mdl_file.read(),
                 )
+            # Remove file after packing
+            mdl_filePath.unlink()
 
     LOGGER.info('Setting up vactube ents...')
     # Generate the shared template.


### PR DESCRIPTION
No

![image](https://github.com/TeamSpen210/HammerAddons/assets/12023782/dd8509e3-242c-4e0a-8a14-672e744f190c)

wat is this

😭 

this addon is very nice, but then I saw this and it changed everything


maybe there's a better way to delete the packed files, command parameter idk, so some can extract it

but do something about it please