### PR TITLE
Original spawnflag name for ambient_generic "Infinite range" to "Play everywhere"

### DIFF
--- a/fgd/point/ambient/ambient_generic.fgd
+++ b/fgd/point/ambient/ambient_generic.fgd
@@ -7,7 +7,7 @@
 	[
 	spawnflags(flags)  =
 		[
-		1: "Infinite Range" : 0
+		1: "Play everywhere" : 0
 		16: "Start Silent" : 1
 		32: "Is NOT Looped" : 1
 		64: "Do NOT Pause when game is Paused": 0 [MESA]


### PR DESCRIPTION
Currently it's set to "Infinite range". This gave me some thinking time to realize that it is "Play everywhere" as it's written here https://developer.valvesoftware.com/wiki/Ambient_generic


