### PR TITLE
Implement "--srctools_only", "--collapse_bases" export parameters

### DIFF
--- a/src/hammeraddons/unify_fgd.py
+++ b/src/hammeraddons/unify_fgd.py
@@ -315,6 +315,7 @@ def load_database(
     extra_loc: Optional[Path]=None,
     fgd_vis: bool=False,
     map_size: int=MAP_SIZE_DEFAULT,
+    srctools_only: bool = False
 ) -> Tuple[FGD, EntityDef]:
     """Load the entire database from disk. This returns the FGD, plus the CBaseEntity definition."""
     print(f'Loading database {dbase}:')
@@ -386,6 +387,25 @@ def load_database(
     print()
 
     fgd.apply_bases()
+    
+    # If compiling only srctools entities for this specific game, iterate over entities...
+    if srctools_only or True:
+        print('Exporting only srctools entities!')
+        delete_entries = []
+        for classname_, ent_ in fgd.entities.items():
+
+            if ent_.type is EntityTypes.BASE: # Do not remove base entries!
+                continue
+
+            tags = get_appliesto(ent_)
+            if not 'SRCTOOLS' in tags and not '+SRCTOOLS' in tags: #Both of these variants declare an entity that is used only by the postcompiler, not in the engine
+                delete_entries.append(classname_)
+        
+        for entry_ in delete_entries:
+            del fgd.entities[entry_]
+            
+        
+
     print('\nDone!')
 
     print('Entities without visgroups:')

--- a/src/hammeraddons/unify_fgd.py
+++ b/src/hammeraddons/unify_fgd.py
@@ -394,7 +394,9 @@ def load_database(
         delete_entries = []
         for classname_, ent_ in fgd.entities.items():
 
-            if ent_.type is EntityTypes.BASE:# Don't delete the base entites, these get culled automatically, and they might be needed
+            if ent_.type is EntityTypes.BASE or classname_ in [ # We also have to declare some manually
+                "_cbaseentity_",
+                ]:# Don't delete the base entites, these get culled automatically, and they might be needed
                 continue
 
             tags = get_appliesto(ent_)
@@ -404,8 +406,6 @@ def load_database(
         for entry_ in delete_entries:
             del fgd.entities[entry_]
 
-        for entry in fgd.entities.items():
-            print(entry)
 
     print('\nDone!')
 

--- a/src/hammeraddons/unify_fgd.py
+++ b/src/hammeraddons/unify_fgd.py
@@ -849,7 +849,8 @@ def action_export(
     as_binary: bool,
     engine_mode: bool,
     map_size: int=MAP_SIZE_DEFAULT,
-    srctools_only: bool = False
+    srctools_only: bool = False,
+    collapse_bases: bool = False
 ) -> None:
     """Create an FGD file using the given tags."""
 
@@ -864,7 +865,7 @@ def action_export(
 
     print(f'Map size: ({fgd.map_size_min}, {fgd.map_size_max})')
 
-    if engine_mode:
+    if engine_mode or collapse_bases:
         # In engine mode, we don't care about specific games.
         print('Collapsing bases...')
         aliases: Dict[EntityDef, Union[str, EntityDef]] = {}
@@ -877,6 +878,7 @@ def action_export(
                 aliases[ent] = base
         fgd.collapse_bases()
 
+    if engine_mode:
         print('Merging tags...')
         for ent in list(fgd):
             # We want to include not-in-engine entities like func_detail still, for parsing
@@ -1279,9 +1281,14 @@ def main(args: Optional[List[str]]=None):
     parser_exp.add_argument(
         "--srctools_only",
         default=False,
-        type=bool,
-        dest="srctools_only",
+        action="store_true",
         help="Export \"comp\" entities."
+    )
+    parser_exp.add_argument(
+        "--collapse_bases",
+        default=False,
+        action="store_true",
+        help="Collapse base classes and merge them into the entity definitions."
     )
 
     parser_imp = subparsers.add_parser(
@@ -1359,7 +1366,8 @@ def main(args: Optional[List[str]]=None):
             result.binary,
             result.engine,
             result.map_size,
-            result.srctools_only
+            result.srctools_only,
+            result.collapse_bases
         )
     elif result.mode in ("c", "count"):
         action_count(dbase, extra_db, factories_folder=Path(repo_dir, 'db', 'factories'), srctools_only=result.srctools_only)

--- a/src/hammeraddons/unify_fgd.py
+++ b/src/hammeraddons/unify_fgd.py
@@ -394,7 +394,7 @@ def load_database(
         delete_entries = []
         for classname_, ent_ in fgd.entities.items():
 
-            if ent_.type is EntityTypes.BASE:# This classname check handles special cases
+            if ent_.type is EntityTypes.BASE:# Don't delete the base entites, these get culled automatically, and they might be needed
                 continue
 
             tags = get_appliesto(ent_)

--- a/src/hammeraddons/unify_fgd.py
+++ b/src/hammeraddons/unify_fgd.py
@@ -389,7 +389,7 @@ def load_database(
     fgd.apply_bases()
     
     # If compiling only srctools entities for this specific game, iterate over entities...
-    if srctools_only or True:
+    if srctools_only:
         print('Exporting only srctools entities!')
         delete_entries = []
         for classname_, ent_ in fgd.entities.items():
@@ -404,6 +404,8 @@ def load_database(
         for entry_ in delete_entries:
             del fgd.entities[entry_]
 
+        for entry in fgd.entities.items():
+            print(entry)
 
     print('\nDone!')
 

--- a/src/hammeraddons/unify_fgd.py
+++ b/src/hammeraddons/unify_fgd.py
@@ -397,8 +397,6 @@ def load_database(
     print()
 
     fgd.apply_bases()
-    
-
 
     print('\nDone!')
 
@@ -1231,12 +1229,6 @@ def main(args: Optional[List[str]]=None):
         help="If specified, an additional folder to read FGD files from. "
              "These override the normal database.",
     )
-    parser.add_argument(
-        "--srctools_only",
-        default=False,
-        action="store_true",
-        help="Export \"comp\" entities."
-    )
     subparsers = parser.add_subparsers(dest="mode")
 
     parser_count = subparsers.add_parser(
@@ -1286,6 +1278,12 @@ def main(args: Optional[List[str]]=None):
         default=False,
         action="store_true",
         help="Collapse base classes and merge them into the entity definitions."
+    )
+    parser_exp.add_argument(
+        "--srctools_only",
+        default=False,
+        action="store_true",
+        help="Export \"comp\" entities."
     )
 
     parser_imp = subparsers.add_parser(


### PR DESCRIPTION
This parameter makes the specified fgd only contain the postcompiler's `comp` entities, for a specific game configuration so tags are still passed as normal.

I'm not sure about this implementation, but it seems to work fine. Feel free to contact me or change this code for a better one if there's a need to do so.