### PR TITLE
feat: Ability to disable transforms

### DIFF
--- a/src/hammeraddons/bsp_transform/__init__.py
+++ b/src/hammeraddons/bsp_transform/__init__.py
@@ -141,6 +141,7 @@ TransFunc = Callable[[Context], Awaitable[None]]
 TransFuncOrSync = Callable[[Context], Optional[Awaitable[None]]]
 TRANSFORMS: Dict[str, TransFunc] = {}
 TRANSFORM_PRIORITY: Dict[str, int] = {}
+TRANSFORM_ID: Dict[str, str] = {}
 
 
 def trans(name: str, *, priority: int=0) -> Callable[[TransFuncOrSync], TransFunc]:
@@ -148,6 +149,7 @@ def trans(name: str, *, priority: int=0) -> Callable[[TransFuncOrSync], TransFun
     def deco(func: TransFuncOrSync) -> TransFunc:
         """Stores the transformation."""
         TRANSFORM_PRIORITY[name] = priority
+        TRANSFORM_ID[name] = func.__name__
         if inspect.iscoroutinefunction(func):
             TRANSFORMS[name] = func
             return func
@@ -181,14 +183,10 @@ async def run_transformations(
     )
 
     disabledSet = { it.strip() for it in disabled.split( ',' ) }
+    enabledTransforms = list( filter( lambda it: TRANSFORM_ID[it[0]] not in disabledSet, sorted( TRANSFORMS.items(), key=lambda tup: TRANSFORM_PRIORITY[tup[0]] ) ) )
+    LOGGER.info( 'Enabled transforms: {}', ', '.join( [ TRANSFORM_ID[it] for it, _ in enabledTransforms ] ) )
 
-    for func_name, func in sorted(
-        TRANSFORMS.items(),
-        key=lambda tup: TRANSFORM_PRIORITY[tup[0]],
-    ):
-        if func_name in disabledSet:
-            continue
-
+    for func_name, func in enabledTransforms:
         LOGGER.info('Running "{}"...', func_name)
         try:
             context.config = config[func_name.casefold()]

--- a/src/hammeraddons/bsp_transform/__init__.py
+++ b/src/hammeraddons/bsp_transform/__init__.py
@@ -170,6 +170,7 @@ async def run_transformations(
     studiomdl_loc: Optional[Path] = None,
     config: Mapping[str, Keyvalues] = EmptyMapping,
     tags: FrozenSet[str] = frozenset(),
+    disabled: str = '',
     modelcompile_dump: Optional[Path] = None,
 ) -> None:
     """Run all transformations."""
@@ -179,10 +180,15 @@ async def run_transformations(
         modelcompile_dump=modelcompile_dump,
     )
 
+    disabledSet = { it.strip() for it in disabled.split( ',' ) }
+
     for func_name, func in sorted(
         TRANSFORMS.items(),
         key=lambda tup: TRANSFORM_PRIORITY[tup[0]],
     ):
+        if func_name in disabledSet:
+            continue
+
         LOGGER.info('Running "{}"...', func_name)
         try:
             context.config = config[func_name.casefold()]

--- a/src/hammeraddons/config.py
+++ b/src/hammeraddons/config.py
@@ -471,3 +471,8 @@ TRANSFORM_OPTS = Opt.block(
     transform, and the value is then decided by that transform.
     """
 )
+
+DISABLED_TRANSFORMS = Opt.string(
+    'transform_disable', '',
+    """Specify transforms to disable as a comma-separated string."""
+)

--- a/src/hammeraddons/postcompiler.py
+++ b/src/hammeraddons/postcompiler.py
@@ -230,6 +230,7 @@ async def main(argv: List[str]) -> None:
         studiomdl_loc,
         transform_conf,
         pack_tags,
+        disabled=conf.otps.get(config.DISABLED_TRANSFORMS),
         modelcompile_dump=modelcompile_dump,
     )
 

--- a/src/hammeraddons/postcompiler.py
+++ b/src/hammeraddons/postcompiler.py
@@ -230,7 +230,7 @@ async def main(argv: List[str]) -> None:
         studiomdl_loc,
         transform_conf,
         pack_tags,
-        disabled=conf.otps.get(config.DISABLED_TRANSFORMS),
+        disabled=conf.opts.get(config.DISABLED_TRANSFORMS),
         modelcompile_dump=modelcompile_dump,
     )
 


### PR DESCRIPTION
Adds the ability to disable transforms via a comma-separated list option (`transform_disable`)

We're trying to be less intrusive on the edits to the postcompiler. As we support a few of the transforms natively, by using a config we can still be compatible while also avoiding the postcompiler trying to do what was already done.