### PR TITLE
Fixed `lua_run` case sensitivity

### DIFF
--- a/fgd/point/lua_run.fgd
+++ b/fgd/point/lua_run.fgd
@@ -3,7 +3,7 @@
 	iconsprite("editor/lua_run.vmt")
 = lua_run : "Runs Lua Code"
 	[
-	code(string) : "Code" : "" : "Lua code to run when triggered"
+	Code(string) : "Code" : "" : "Lua code to run when triggered"
 
 	spawnflags(flags) =
 		[


### PR DESCRIPTION
_Garry's Mod_'s `lua_run` entity performs a _case sensitive_ search for the `Code` KV pair, which was swapped to all-lowercase in HammerAddons' unified FGD.

The currently available `lua_run.fgd` does not function by default and requires mappers to disable SmartEdit and correct the casing themselves to fix it (Hammer will automatically revert a manually corrected `Code` KV pair back to the unified FGD's `code` key upon its activation).