### PR TITLE
Fix engine_mode ability to be False even when -b is passed

### DIFF
--- a/src/hammeraddons/unify_fgd.py
+++ b/src/hammeraddons/unify_fgd.py
@@ -1358,7 +1358,7 @@ def main(args: Optional[List[str]]=None):
             tags,
             result.output,
             result.binary,
-            result.engine,
+            result.engine | result.binary, # Binary mode forces --engine
             result.map_size,
             result.srctools_only,
             result.collapse_bases


### PR DESCRIPTION
Binary export relies on engine mode flag to be set to true, this fixes the issue if user has not passed --engine manually