### PR TITLE
Enable game mounting in srctools.vdf

### DIFF
--- a/postcompiler.spec
+++ b/postcompiler.spec
@@ -39,7 +39,7 @@ a = Analysis(
         'bisect', 'colorsys', 'collections', 'csv', 'datetime', 'contextlib',
         'decimal', 'difflib', 'enum', 'fractions', 'functools',
         'io', 'itertools', 'json', 'math', 'random', 're',
-        'statistics', 'string', 'struct',
+        'statistics', 'string', 'struct', 'pysteampathprovider',
         *collect_submodules('srctools', filter=lambda name: 'scripts' not in name),
         *collect_submodules('attr'),
         *collect_submodules('attrs'),

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ trio >= 0.20.0
 trio-typing >= 0.7.0
 pyinstaller >= 6.1.0
 versioningit >= 2.1.0
-pysteampathprovider >= 1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ trio >= 0.20.0
 trio-typing >= 0.7.0
 pyinstaller >= 6.1.0
 versioningit >= 2.1.0
+pysteampathprovider >= 1.3

--- a/src/hammeraddons/config.py
+++ b/src/hammeraddons/config.py
@@ -14,7 +14,7 @@ import attrs
 from .plugin import BUILTIN as BUILTIN_PLUGIN, PluginFinder, Source as PluginSource
 from .props_config import Opt, Options
 
-from pysteampathprovider import GetApp
+from srctools.game_mount import GetApp
 
 LOGGER = logger.get_logger(__name__)
 CONF_NAME: Final = 'srctools.vdf'

--- a/src/hammeraddons/config.py
+++ b/src/hammeraddons/config.py
@@ -196,7 +196,8 @@ def parse(map_path: Path, game_folder: Optional[str]='') -> Config:
             raise ValueError('Config "searchpaths" value cannot have children.')
         assert isinstance(kv.value, str)
 
-        if kv.value.startswith("<") and (end := kv.value.find(">")): #Game mount, we just replace the <appid> with a path, this will ensure compatibility with .vpk
+        st = None
+        if (end := kv.value.find(">")) and kv.value.startswith("<"): #Game mount, we just replace the <appid> with a path, this will ensure compatibility with .vpk
             st = kv.value[1:end] # Omit the first character, <
             try:
                 st = int(st)


### PR DESCRIPTION
Now srctools.vdf supports the `<appid>` syntax in the Searchpaths block.
For example, `<620>/portal2` will expand out to `C:/Program Files/.../steamapps/common/Portal 2/portal2`, based on where the user has installed Portal 2