### PR TITLE
Fix disabled transforms not being casefolded before comparison

### DIFF
--- a/src/hammeraddons/postcompiler.py
+++ b/src/hammeraddons/postcompiler.py
@@ -230,7 +230,7 @@ async def main(argv: List[str]) -> None:
         studiomdl_loc,
         transform_conf,
         pack_tags,
-        disabled={name.strip() for name in conf.opts.get(config.DISABLED_TRANSFORMS).split(',')},
+        disabled={name.strip().casefold() for name in conf.opts.get(config.DISABLED_TRANSFORMS).split(',')},
         modelcompile_dump=modelcompile_dump,
     )
 


### PR DESCRIPTION
Tiny little fix to make the new `transform_disable` a bit easier to work with. As is, the code casefolds the transform names, but not the names in the config parameter. Therefore, the only way to disable these at the moment is to lowercase everything in the value of `transform_disable`. This makes it a little nicer to work with.